### PR TITLE
T0450-Supplier bank change approval

### DIFF
--- a/supplier_bank_change_approval/__init__.py
+++ b/supplier_bank_change_approval/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import controllers
+from . import models

--- a/supplier_bank_change_approval/__manifest__.py
+++ b/supplier_bank_change_approval/__manifest__.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "Supplier Bank Account Approval",
+
+    'summary': """
+        Supplier Bank Account Approval""",
+
+    'description': """
+        \n1.Add state draft and confirmed to the banks_account_ids from partner.
+        \nThis should only apply to partners is supplier = true
+        \n2.New menu called 'Sensitive fields approval' where any changes can be approved. 
+        \nThis menu should only be visible and available to new security group 'Bank Account Manager'
+        \n3.When a bank account is changed or added, it will be in draft state. It cannot be used in any invoice or payment.
+        \nwhen creating an invoice or payment which says that "The supplier has changed bank details which are not yet approved.
+        """,
+
+    'author': "Magnus-Sify",
+    'website': "http://www.magnus.nl",
+
+    # Categories can be used to filter modules in modules listing
+    # Check https://github.com/odoo/odoo/blob/10.0/odoo/addons/base/module/module_data.xml
+    # for the full list
+    'category': 'Uncategorized',
+    'version': '0.1',
+
+    # any module necessary for this one to work correctly
+    'depends': ['base','account'],
+
+    # always loaded
+    'data': [
+        # 'security/ir.model.access.csv',
+        'views/views.xml',
+        'views/templates.xml',
+        'demo/demo.xml',
+    ],
+    # only loaded in demonstration mode
+    'demo': [
+        'demo/demo.xml',
+    ],
+}

--- a/supplier_bank_change_approval/controllers/__init__.py
+++ b/supplier_bank_change_approval/controllers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import controllers

--- a/supplier_bank_change_approval/controllers/controllers.py
+++ b/supplier_bank_change_approval/controllers/controllers.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+
+# class SupplierBankChangeApproval(http.Controller):
+#     @http.route('/supplier_bank_change_approval/supplier_bank_change_approval/', auth='public')
+#     def index(self, **kw):
+#         return "Hello, world"
+
+#     @http.route('/supplier_bank_change_approval/supplier_bank_change_approval/objects/', auth='public')
+#     def list(self, **kw):
+#         return http.request.render('supplier_bank_change_approval.listing', {
+#             'root': '/supplier_bank_change_approval/supplier_bank_change_approval',
+#             'objects': http.request.env['supplier_bank_change_approval.supplier_bank_change_approval'].search([]),
+#         })
+
+#     @http.route('/supplier_bank_change_approval/supplier_bank_change_approval/objects/<model("supplier_bank_change_approval.supplier_bank_change_approval"):obj>/', auth='public')
+#     def object(self, obj, **kw):
+#         return http.request.render('supplier_bank_change_approval.object', {
+#             'object': obj
+#         })

--- a/supplier_bank_change_approval/demo/demo.xml
+++ b/supplier_bank_change_approval/demo/demo.xml
@@ -1,0 +1,8 @@
+<odoo>
+    <data>
+        <record id="bank_account_manager" model="res.groups">
+            <field name="name">Bank Account Manager</field>
+            <field name="category_id" ref="base.module_category_accounting_and_finance"/>
+        </record>
+    </data>
+</odoo>

--- a/supplier_bank_change_approval/models/__init__.py
+++ b/supplier_bank_change_approval/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import supplier_bank_change_approval

--- a/supplier_bank_change_approval/models/supplier_bank_change_approval.py
+++ b/supplier_bank_change_approval/models/supplier_bank_change_approval.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError
+
+class SupplierBankApproval(models.Model):
+   
+       #Update vendor bank account with states 
+    
+    _inherit = 'res.partner.bank'
+    
+    state = fields.Selection([('draft', "Draft"),('confirmed', "Confirmed")],default='draft',string='Status', copy=False, index=True,readonly=True, store=True,track_visibility='always')
+    @api.multi
+    def action_draft(self):
+        self.state = 'draft'
+
+    @api.multi
+    def action_confirm(self):
+        self.state = 'confirmed'
+       
+    @api.multi
+    def write(self, vals):
+        # Update vendor bank account then  
+        # :return:state Draft
+        
+        if self.partner_id.supplier==True:
+            if self.state=='confirmed':
+                vals.update({'state' : 'draft'})
+        return super(SupplierBankApproval, self).write(vals)
+
+class AccountSupplierBankCheck(models.Model):
+    # Update vendor bank account in account invoice on_change checking
+    
+    _inherit = 'account.invoice'
+        
+    @api.multi
+    @api.constrains('partner_id')
+    def _check_partner_id(self):
+        bank_list=[]
+        if self.type=='in_invoice':
+            partner=self.env['res.partner.bank'].search([('partner_id.id', '=', self.partner_id.id)])
+            for bank in partner:
+                bank_list.append(bank.state)
+                if 'confirmed' not in bank_list:
+                    raise UserError(_('The supplier has changed bank details which are not yet approved.'))
+            
+                 
+            
+class PaymentSupplierBankCheck(models.Model):
+    
+    # Update  vendor bank account in account payment checking
+    
+    _inherit = 'account.payment'
+
+    @api.constrains('partner_id')
+    def _check_partner_id(self):
+        bank_payment_list=[]
+        if self.partner_id.supplier==True:
+            partner=self.env['res.partner.bank'].search([('partner_id.id', '=', self.partner_id.id)])
+            for bank in partner:
+                bank_payment_list.append(bank.state)
+            if 'confirmed' not in bank_payment_list:
+                raise UserError(_('The supplier has changed bank details which are not yet approved.'))
+
+
+          
+
+
+            

--- a/supplier_bank_change_approval/security/ir.model.access.csv
+++ b/supplier_bank_change_approval/security/ir.model.access.csv
@@ -1,0 +1,2 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_supplier_bank_change_approval_supplier_bank_change_approval,supplier_bank_change_approval.supplier_bank_change_approval,model_supplier_bank_change_approval_supplier_bank_change_approval,,1,0,0,0

--- a/supplier_bank_change_approval/views/templates.xml
+++ b/supplier_bank_change_approval/views/templates.xml
@@ -1,0 +1,22 @@
+<odoo>
+    <data>
+        <!-- <template id="listing"> -->
+        <!--   <ul> -->
+        <!--     <li t-foreach="objects" t-as="object"> -->
+        <!--       <a t-attf-href="#{ root }/objects/#{ object.id }"> -->
+        <!--         <t t-esc="object.display_name"/> -->
+        <!--       </a> -->
+        <!--     </li> -->
+        <!--   </ul> -->
+        <!-- </template> -->
+        <!-- <template id="object"> -->
+        <!--   <h1><t t-esc="object.display_name"/></h1> -->
+        <!--   <dl> -->
+        <!--     <t t-foreach="object._fields" t-as="field"> -->
+        <!--       <dt><t t-esc="field"/></dt> -->
+        <!--       <dd><t t-esc="object[field]"/></dd> -->
+        <!--     </t> -->
+        <!--   </dl> -->
+        <!-- </template> -->
+    </data>
+</odoo>

--- a/supplier_bank_change_approval/views/views.xml
+++ b/supplier_bank_change_approval/views/views.xml
@@ -1,0 +1,38 @@
+<odoo>
+  <data>
+
+    <record model="ir.ui.view" id="supplier_bank_change_approval.list">
+      <field name="name">supplier_bank_change_approval list</field>
+      <field name="model">res.partner.bank</field>
+      <field name="inherit_id" ref="base.view_partner_bank_form"/>
+      <field name="groups_id" eval="[(6, 0, [ref('supplier_bank_change_approval.bank_account_manager') ])]"/>
+      <field name="arch" type="xml">
+        <xpath expr="//form" position="inside">
+
+          <header>
+            <button name="action_confirm" type="object" string="Confirm" states="draft" class="oe_highlight"/>
+            <field name="state" widget="statusbar"/>
+          </header>
+        </xpath>
+      </field>
+    </record>
+
+
+    <!-- actions opening views on models -->
+
+    <record model="ir.actions.act_window" id="supplier_bank_change_approval.action_window">
+      <field name="name">Sensitive Fields Approval</field>
+      <field name="res_model">res.partner.bank</field>
+      <field name="view_mode">tree,form</field>
+      <field name="groups_id" eval="[(6, 0, [ref('supplier_bank_change_approval.bank_account_manager') ])]"/>
+      <field name="domain">['&amp;',('partner_id.supplier', '=', 'True'),('state', '=', 'draft')]</field>
+    </record>
+
+
+    <menuitem name="Sensitive Fields Approval" id="sensitive_fields_approval"/>
+
+    <menuitem id="sensitive_fields_approval_1" name="Bank Account Approval" parent="sensitive_fields_approval" action="supplier_bank_change_approval.action_window" sequence="3" groups='supplier_bank_change_approval.bank_account_manager'/>
+
+
+  </data>
+</odoo>


### PR DESCRIPTION
1.Add state draft and confirmed to the banks_account_ids from partner.
   This should only apply to partners is supplier = true
2.New menu called 'Sensitive fields approval' where any changes can be approved. 
     This menu should only be visible and available to new security group 'Bank Account Manager'
3.When a bank account is changed or added, it will be in draft state. It cannot be used in any invoice or payment.
    when creating an invoice or payment which says that "The supplier has changed bank details which are not yet approved.