### PR TITLE
T0552 - Supplier invoice bank contraints

### DIFF
--- a/invoice_duplication_bank_account_check/models/invoice_duplication_bank_account_check.py
+++ b/invoice_duplication_bank_account_check/models/invoice_duplication_bank_account_check.py
@@ -25,18 +25,22 @@ class InvoiceDuplicationBankCheck(models.Model):
     @api.multi   
     def copy(self, default):
         default = dict(default or {})
-        if self.type=='in_invoice':
+        if self.type=='in_invoice' or self.type=='in_refund':
             if self.partner_bank_id.id != False and self.partner_bank_id.partner_id.id==False:
-                default.update({'partner_bank_id':False,'copy_record':True})  
-        return super(InvoiceDuplicationBankCheck, self).copy(default)            
+                default.update({'partner_bank_id':False,'copy_record':True})
+            elif self.partner_bank_id.id != False and self.partner_bank_id.partner_id.id != self.partner_id.id:
+                default.update({'partner_bank_id': False, 'copy_record': True})
+            return super(InvoiceDuplicationBankCheck, self).copy(default)
     
                      
     #  validating the partner_bank_id is link to res.partner           
             
     def invoice_validate(self):
-        if self.type=='in_invoice':
+        if self.type=='in_invoice'  or self.type=='in_refund' :
             if self.partner_bank_id.id != False and self.partner_bank_id.partner_id.id==False:
-                raise UserError('The partner bank details have changed. Check the bank details')                  
+                raise UserError('The partner bank details have changed. Check the bank details')
+            elif self.partner_bank_id.id != False and self.partner_bank_id.partner_id.id != self.partner_id.id:
+                raise UserError('The bank account partner for this invoice is not the same as the partner in the bank account',)
         return super(InvoiceDuplicationBankCheck, self).invoice_validate()
 
     


### PR DESCRIPTION
add a constraint on the account_invoice.partner_bank_id that checks if the res_partner_bank.partner_id = account_invoice.partner_id . If the partners are not the same, a error should appear "The bank account partner for this invoice is not the same as the partner in the bank account"

Also add a 'no copy' on the partner bank id for the account_invoice object so that the bank id is not copied when duplicating an invoice