### PR TITLE
Module bi_sql_excel_reports: Now using the report ID instead of the s…

### DIFF
--- a/bi_sql_excel_reports/__manifest__.py
+++ b/bi_sql_excel_reports/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "BI SQL Excel Reports",
     "summary": "Pull SQL reports, defined in Odoo from within Excel, using the Excel add-in and this module to define the pivot layout.",
-    "version": "10.0.1.1.5",
+    "version": "10.0.1.1.6",
     "author": "Magnus",
     "website": "https://www.magnus.nl/",
     "license": "AGPL-3",

--- a/bi_sql_excel_reports/views/view_bi_sql_excel_report.xml
+++ b/bi_sql_excel_reports/views/view_bi_sql_excel_report.xml
@@ -72,7 +72,10 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                             </group>
                         </page>
                         <page string="Fields" id="fields">
-                            <field name="field_ids" context="{'default_is_select_index':is_select_index}" />
+                            <field name="field_ids" context="{
+                             'parent_report_id':id,
+                             'parent_report_query_name':query_name,
+                             'parent_report_is_select_index':is_select_index}" />
                         </page>
                     </notebook>
                 </sheet>
@@ -84,7 +87,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="name">SQL Excel Reports List</field>
             <field name="model">bi.sql.excel.report</field>
             <field name="arch" type="xml">
-                <tree string="Excel reports">
+                <tree string="Excel reports" decoration-info="is_group==True" decoration-warning="is_select_index==True">
                     <field name="id" invisible="1"/>
                     <field name="sequence"/>
                     <field name="name"/>
@@ -108,9 +111,9 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                     <field name="short_name"/>
                     <field name="query_name"/>
                     <field name="chart_type"/>
-                    <filter string="Reports only"
+                    <filter string="Reports"
                         domain="[('is_select_index','=',False)]"/>
-                    <filter string="Selection Indexes only"
+                    <filter string="Selection Indexes"
                         domain="[('is_select_index','=',True)]"/>
                     <filter string="Having queries"
                         domain="[('query_name','!=',False)]"/>


### PR DESCRIPTION
…equence because a sequence may not be unique. Added field selections (bi.sql.excel.report) for query_name (selecting from bi.sql.view) and chart_type (Excel values). Added logic to suggest the next available sequence number for both bi.sql.excel.report and bi.sql.excel.report.field.

Added field selections (bi.sql.excel.report.field) for name (field names from the query) and for pivot_area.