### PR TITLE
[FIX] invoice_line_revenue_distribution_operating_unit: missing dependency

### DIFF
--- a/invoice_line_revenue_distribution_operating_unit/__manifest__.py
+++ b/invoice_line_revenue_distribution_operating_unit/__manifest__.py
@@ -26,7 +26,7 @@
     'version': '10.0.1.1.0',
 
     # any module necessary for this one to work correctly
-    'depends': ['sale','account_operating_unit','analytic_operating_unit'],
+    'depends': ['sale','account_operating_unit','analytic_operating_unit', 'sale_operating_unit'],
 
     # always loaded
     'data': [


### PR DESCRIPTION
this does not imply a proper migration of this module, just that it won't break things when being installed